### PR TITLE
build: combine the two docker containers 'lrar_backend' and 'lrar_die…

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,22 +1,34 @@
 FROM rust:latest AS builder
 
-RUN apt-get update && apt-get install -y libpq-dev && rm -rf /var/lib/apt/lists/*
+RUN apt update \
+&& apt upgrade -y \
+&& apt install -y libpq-dev \
+&& rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
+WORKDIR /lrar/backend
 
-COPY backend /app
+COPY backend /lrar/backend
 
-RUN cargo build --release
+RUN cargo install diesel_cli --no-default-features --features postgres
+
+RUN cargo build
 
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y libpq5 libssl-dev && rm -rf /var/lib/apt/lists/*
+RUN apt update \
+&& apt upgrade -y \
+&& apt install -y libpq5 ca-certificates \
+&& rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
+WORKDIR /lrar/backend
 
-COPY --from=builder /app/target/release/backend /app/backend_binary
+COPY --from=builder /lrar/backend/target/debug/backend ./backend_binary
 
-COPY backend/assets /app/backend/assets
+COPY --from=builder /usr/local/cargo/bin/diesel /usr/local/bin/diesel
+
+RUN mkdir -p /lrar/backend/migrations
+
+COPY backend/assets /lrar/backend/assets
 
 EXPOSE 3001
 

--- a/backend/diesel.toml
+++ b/backend/diesel.toml
@@ -6,4 +6,4 @@ file = "src/schema.rs"
 custom_type_derives = ["diesel::query_builder::QueryId", "Clone"]
 
 [migrations_directory]
-dir = "/diesel/backend/migrations"
+dir = "/lrar/backend/migrations"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -72,7 +72,7 @@ async fn main() -> std::io::Result<()> {
     HttpServer::new(move || {
         App::new()
             .app_data(web::Data::new(pool.clone()))
-            .service(fs::Files::new("/images", "./backend/assets/tenants_images").show_files_listing())
+            .service(fs::Files::new("/images", "/lrar/backend/assets/tenants_images").show_files_listing())
             .wrap(
                 Cors::default()
                     .allowed_origin("http://localhost:5173")

--- a/diesel/Dockerfile
+++ b/diesel/Dockerfile
@@ -1,5 +1,0 @@
-FROM rust:latest
-
-WORKDIR /diesel
-
-RUN cargo install diesel_cli --no-default-features --features postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,14 @@ services:
       - "3001:3001"
     environment:
       DATABASE_URL: ${DATABASE_URL}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - ./backend/migrations:/lrar/backend/migrations
+    depends_on:
+      db:
+        condition: service_healthy
     networks:
       - app-network
 
@@ -41,21 +49,6 @@ services:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 5s
       retries: 5
-
-  diesel:
-    container_name: lrar_diesel_orm
-    build:
-      context: .
-      dockerfile: diesel/Dockerfile
-    environment:
-      DATABASE_URL: ${DATABASE_URL}
-    depends_on:
-      - db
-    networks:
-      - app-network
-    volumes:
-      - .:/diesel
-    command: sleep infinity
 
 volumes:
   db-data:


### PR DESCRIPTION
…sel_orm' into a single docker container. It is not necessary to have a dedicated docker container for Diesel, as it was just a temporary 'hacky' solution.