### PR TITLE
Created notes tables in DB

### DIFF
--- a/backend/migrations/2025-02-07-094642_create_notes/down.sql
+++ b/backend/migrations/2025-02-07-094642_create_notes/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE notes;

--- a/backend/migrations/2025-02-07-094642_create_notes/up.sql
+++ b/backend/migrations/2025-02-07-094642_create_notes/up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE notes (
+    id SERIAL PRIMARY KEY,
+    message TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -11,6 +11,14 @@ diesel::table! {
 }
 
 diesel::table! {
+    notes (id) {
+        id -> Int4,
+        message -> Text,
+        created_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     tenants (id) {
         id -> Int4,
         name -> Varchar,
@@ -24,5 +32,6 @@ diesel::table! {
 
 diesel::allow_tables_to_appear_in_same_query!(
     burn,
+    notes,
     tenants,
 );


### PR DESCRIPTION
This pull request introduces a new `notes` table in the database schema. The changes include creating the table with appropriate fields, updating the schema file, and allowing the new table to appear in the same query as other tables.

Database schema updates:

* [`backend/migrations/2025-02-07-094642_create_notes/up.sql`](diffhunk://#diff-9f0a0eb8f06f84dd63c1dbbf3823a5b6371b745924a8e4c09b68068bcd98a881R1-R5): Added a new `notes` table with fields `id`, `message`, and `created_at`.
* [`backend/migrations/2025-02-07-094642_create_notes/down.sql`](diffhunk://#diff-cc4f4b94d50a089563bfd6096d2bf74249e04fdecf995751c3aff49384a6b929R1): Added a command to drop the `notes` table.

Schema file updates:

* [`backend/src/schema.rs`](diffhunk://#diff-f7fdbc3878d93c8eec1b79344f39b197bc42107c424360ee86de1c8e53c0a468R13-R20): Added `notes` table definition to the schema.
* [`backend/src/schema.rs`](diffhunk://#diff-f7fdbc3878d93c8eec1b79344f39b197bc42107c424360ee86de1c8e53c0a468R35): Updated the list of tables allowed to appear in the same query to include `notes`.