### PR TITLE
fix: chore-rotation not working properly when number of tenants does not equal number of chores

### DIFF
--- a/backend/src/endpoints.rs
+++ b/backend/src/endpoints.rs
@@ -71,14 +71,7 @@ pub async fn get_tenants(pool: web::Data<DbPool>) -> Result<HttpResponse, Error>
     // Base URL for images
     let base_url = "http://localhost:3001/images/";
 
-    let mut all_tenant_chores = get_weekly_chore();
-
-    if tenants_data.len() > all_tenant_chores.len() {
-        println!("Number of chores are less than the number of tenants. Adding empty chroe to avoid truncation");
-        for _ in 0..(tenants_data.len() - all_tenant_chores.len()) {
-            all_tenant_chores.push("Nothing".to_string());
-        }
-    } 
+    let all_tenant_chores = get_weekly_chore(tenants_data.len()); 
 
     let response_data: Vec<TenantResponse> = tenants_data
         .into_iter()

--- a/backend/src/utils.rs
+++ b/backend/src/utils.rs
@@ -3,8 +3,8 @@ use diesel::{PgConnection, RunQueryDsl};
 use crate::models::{Burn, BurnDto, NewTenant};
 use crate::models::Tenant;
 
-pub fn get_weekly_chore() -> Vec<String> {
-    let all_chores: Vec<String> = vec![
+pub fn get_weekly_chore(n_tenants: usize) -> Vec<String> {
+    let mut all_chores: Vec<String> = vec![
         "Clean the kitchen".to_string(),
         "Clean the toilet".to_string(),
         "Clean the bathroom".to_string(),
@@ -12,6 +12,14 @@ pub fn get_weekly_chore() -> Vec<String> {
         "Clean the living room".to_string(),
         "Take out all trash".to_string(),
     ];
+
+    let n_missing = n_tenants - all_chores.len(); //Number of missing chores
+
+    if n_missing > 0 {
+        for _ in 0..(n_missing) {
+            all_chores.push("Nothing".to_string());
+        }
+    }
 
     //Arbritrary start date
     let start_date = NaiveDate::from_ymd_opt(2024, 12, 9).expect("Invalid date");


### PR DESCRIPTION
This PR fixes a bug where the chore rotation would not rotate the "nothing"- chores. The bug was:

If there were less chores than the amount of tenants we add "nothing" as extra chores, so that the rotation system would work. They were however not rotated, so some tenants would be free of cleaning for their entire recidency, which is unfair. 

The fix was to move the adding of the "nothign"-chores into the get_weekly_chore function, before the rotation is done. 

To test it, create a number of tenants grater than the number of chores (default n_chores = 6). THen build the program. Note which tenants has which chores. Then change the date to another week (example: move back 7 days) and see that it rotates.