### PR TITLE
Added current_burn_count to tenant table

### DIFF
--- a/backend/migrations/2025-02-24-150001_add_current_burn_count/down.sql
+++ b/backend/migrations/2025-02-24-150001_add_current_burn_count/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE tenants
+DROP COLUMN current_burn_count;

--- a/backend/migrations/2025-02-24-150001_add_current_burn_count/up.sql
+++ b/backend/migrations/2025-02-24-150001_add_current_burn_count/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+ALTER TABLE tenants
+ADD COLUMN current_burn_count INTEGER DEFAULT 0;

--- a/backend/src/endpoints.rs
+++ b/backend/src/endpoints.rs
@@ -179,6 +179,7 @@ pub async fn get_tenants(pool: web::Data<DbPool>) -> Result<HttpResponse, Error>
             dishwasher_count: tenant.dishwasher_count,
             favorite_quote: tenant.favorite_quote,
             weekly_chore: weekly_chore,
+            current_burn_count: tenant.current_burn_count,
         })
         .collect();
 

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -28,6 +28,7 @@ pub struct Tenant {
     pub burn_count: Option<i32>,
     pub dishwasher_count: Option<i32>,
     pub favorite_quote: Option<String>,
+    pub current_burn_count: Option<i32>,
 }
 
 #[derive(Insertable, Serialize, Deserialize, Debug)]
@@ -39,6 +40,7 @@ pub struct NewTenant {
     pub burn_count: Option<i32>,
     pub dishwasher_count: Option<i32>,
     pub favorite_quote: Option<String>,
+    pub current_burn_count: Option<i32>,
 }
 
 #[derive(Serialize)]
@@ -51,6 +53,7 @@ pub struct TenantResponse {
     pub dishwasher_count: Option<i32>,
     pub favorite_quote: Option<String>,
     pub weekly_chore: String,
+    pub current_burn_count: Option<i32>,
 }
 
 #[derive(Queryable, Selectable, Serialize, Debug)]

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -27,6 +27,7 @@ diesel::table! {
         burn_count -> Nullable<Int4>,
         dishwasher_count -> Nullable<Int4>,
         favorite_quote -> Nullable<Text>,
+        current_burn_count -> Nullable<Int4>,
     }
 }
 

--- a/frontend/src/components/TenantComponent.vue
+++ b/frontend/src/components/TenantComponent.vue
@@ -4,7 +4,7 @@
       <h2> {{ tenant.name }}, {{ tenant.age }} år</h2>
       <img :src="tenant.image_url" alt="Tenant image">
       <p> Tatt ut av oppvaskmaskinen {{ tenant.dishwasher_count }} ganger </p>
-      <p> Burns: {{ tenant.burn_count }} </p>
+      <p> Burns: {{ tenant.current_burn_count }} </p>
       <p> Weekly chore: {{ tenant.weekly_chore.toLowerCase() }} </p>
       <p style="font-style:italic;">{{ tenant.favorite_quote }}</p>
       <button @click="openBurnForm(tenant)">Give Burn</button>
@@ -36,6 +36,7 @@ interface Tenant {
   dishwasher_count: number,
   favorite_quote: string
   weekly_chore: string,
+  current_burn_count: number,
 }
 
 export default defineComponent ({


### PR DESCRIPTION
This pull request introduces a new `current_burn_count` column to the `tenants` table and integrates it throughout the backend and frontend codebases. The most important changes include adding the new column in the database schema, updating the relevant backend models and endpoints, and modifying the frontend component to display the new field.

Database schema changes:

* [`backend/migrations/2025-02-24-150001_add_current_burn_count/up.sql`](diffhunk://#diff-b9d89e43bfece35047728d61489f8dd1db94e822fe372d28b2963381ae3973edR1-R3): Added `current_burn_count` column to `tenants` table with a default value of 0.
* [`backend/migrations/2025-02-24-150001_add_current_burn_count/down.sql`](diffhunk://#diff-7b2c01ae0338e56fbe6acb613510cae50c33077bb6b96b050692654c111e1a96R1-R3): Added migration to drop `current_burn_count` column from `tenants` table.
* [`backend/src/schema.rs`](diffhunk://#diff-f7fdbc3878d93c8eec1b79344f39b197bc42107c424360ee86de1c8e53c0a468R30): Updated schema to include `current_burn_count` as a nullable integer.

Backend model and endpoint updates:

* [`backend/src/models.rs`](diffhunk://#diff-937627b2b9448f68ee078e8ff22711395412e0f7e837d91477c6c29e314f879fR31): Added `current_burn_count` field to `Tenant`, `NewTenant`, and `TenantResponse` structs. [[1]](diffhunk://#diff-937627b2b9448f68ee078e8ff22711395412e0f7e837d91477c6c29e314f879fR31) [[2]](diffhunk://#diff-937627b2b9448f68ee078e8ff22711395412e0f7e837d91477c6c29e314f879fR43) [[3]](diffhunk://#diff-937627b2b9448f68ee078e8ff22711395412e0f7e837d91477c6c29e314f879fR56)
* [`backend/src/endpoints.rs`](diffhunk://#diff-ba6e42a232c6f85f73aed30139f78bd63af846107f07a0cd0aeb6a4240bc1724R182): Included `current_burn_count` in the `get_tenants` endpoint response.

Frontend component update:

* [`frontend/src/components/TenantComponent.vue`](diffhunk://#diff-a907e5194a380b95232657607c2d17d0e801d180244424b3ae81c842f7c93038L7-R7): Updated to display `current_burn_count` instead of `burn_count` and added `current_burn_count` to the `Tenant` interface. [[1]](diffhunk://#diff-a907e5194a380b95232657607c2d17d0e801d180244424b3ae81c842f7c93038L7-R7) [[2]](diffhunk://#diff-a907e5194a380b95232657607c2d17d0e801d180244424b3ae81c842f7c93038R39)