### PR TITLE
burn counts now update when tenant gets a burn

### DIFF
--- a/backend/src/utils.rs
+++ b/backend/src/utils.rs
@@ -89,6 +89,22 @@ pub fn insert_new_tenant(
     query_result
 }
 
+pub fn give_burn_to_tenant(
+    conn: &mut PgConnection,
+    burned_tenant_id: i32,
+) -> diesel::QueryResult<()> {
+    use diesel::prelude::*;
+    use crate::schema::tenants::dsl::*;
+    diesel::update(tenants.filter(id.eq(burned_tenant_id)))
+    .set((
+        burn_count.eq(burn_count + 1),
+        current_burn_count.eq(current_burn_count + 1),
+    ))
+    .execute(conn)?;
+
+    Ok(())
+}
+
 pub async fn id_to_name(tenant_id: i32, tenants: &[Tenant]) -> String {
     for tenant in tenants {
         if tenant_id == tenant.id {


### PR DESCRIPTION
Closes #59 

This pull request includes changes to the `backend/src/endpoints.rs` and `backend/src/utils.rs` files to enhance the functionality of the burn creation endpoint. The most important changes include adding a new function to update the burn count for tenants and modifying the burn creation logic to incorporate this update.

Enhancements to burn creation functionality:

* [`backend/src/endpoints.rs`](diffhunk://#diff-ba6e42a232c6f85f73aed30139f78bd63af846107f07a0cd0aeb6a4240bc1724L9-R52): Modified the `create_burn` function to include logic for checking if a tenant exists and updating the tenant's burn count when a new burn is created. This involves calling the newly added `give_burn_to_tenant` function.

New utility function:

* [`backend/src/utils.rs`](diffhunk://#diff-8c8d45bab63afc0003d82ea9dfe9b5c3425317a992df6ba40ed43929f6fff82eR92-R107): Added a new function `give_burn_to_tenant` that increments the `burn_count` and `current_burn_count` by one in the database:)