### PR TITLE
feat: Add button to show burns to tenants

### DIFF
--- a/frontend/src/components/TenantBurnHistoryComponent.vue
+++ b/frontend/src/components/TenantBurnHistoryComponent.vue
@@ -1,0 +1,114 @@
+<template>
+    <div class="tenant-burn-history-overlay"> 
+      <div class="tenant-burn-history">
+        <h3>Burn History for {{ tenant.name }}</h3>
+        <div v-if="loading">Loading burn data...</div>
+        <div v-else-if="error">{{ error }}</div>
+        <div v-else>
+          <p v-if="burns.length === 0">No burns found for this tenant.</p>
+          <ul v-else class="burn-list"> 
+            <li
+              v-for="burn in burns"
+              :key="burn.id"
+              class="burn-item"       
+            >
+              <p>Reason: {{ burn.reason }}</p>
+              <p>From: {{ burn.giver_name }}</p>
+              <p>To: {{ burn.receiver_name }}</p>
+              <p>Created: {{ burn.created_at }}</p>
+            </li>
+          </ul>
+        </div>
+        <button class="close-burn-history" @click="$emit('close')">Close</button>
+      </div>
+    </div>
+  </template>
+  
+  <script>
+  export default {
+    name: 'TenantBurnHistoryComponent',
+    props: {
+      tenant: {
+        type: Object,
+        required: true
+      }
+    },
+    data() {
+      return {
+        burns: [],
+        loading: false,
+        error: null
+      };
+    },
+    mounted() {
+      this.fetchBurns();
+    },
+    methods: {
+      fetchBurns() {
+        this.loading = true;
+        fetch(`http://localhost:3001/tenants/${this.tenant.id}/burns`)
+          .then(response => {
+            if (!response.ok) {
+              return response.json().then(data => {
+                throw new Error(data.error || `HTTP error ${response.status}`);
+              });
+            }
+            return response.json();
+          })
+          .then(result => {
+            this.burns = result.data || [];
+          })
+          .catch(err => {
+            this.error = err.message || 'Unknown error';
+          })
+          .finally(() => {
+            this.loading = false;
+          });
+      }
+    }
+  };
+  </script>
+  
+  <style scoped>
+  .tenant-burn-history-overlay {  
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  
+  .tenant-burn-history { 
+    background: white;
+    padding: 20px;
+    border-radius: 8px;
+    width: 400px; 
+    max-height: 80vh; 
+    overflow-y: auto; 
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+  }
+  
+  .burn-list { 
+    margin-top: 1rem;
+    padding: 0; 
+  }
+  
+  .burn-item {
+    list-style-type: none;    
+    padding: 0.5rem;
+    margin-bottom: 0.5rem;
+    border-bottom: 1px solid #eee;
+  }
+  
+  .close-burn-history {
+    margin-top: 10px;
+    background: #ccc;
+    border: none;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+  }
+  </style>

--- a/frontend/src/components/TenantComponent.vue
+++ b/frontend/src/components/TenantComponent.vue
@@ -1,97 +1,101 @@
 <template>
   <div v-if="tenants.length" class="all-tenants-div">
     <div v-for="tenant in tenants" :key="tenant.name" class="tenant-div">
-      <h2> {{ tenant.name }}, {{ tenant.age }} år</h2>
+      <h2>{{ tenant.name }}, {{ tenant.age }} år</h2>
       <img :src="tenant.image_url" alt="Tenant image">
-      <p> Tatt ut av oppvaskmaskinen {{ tenant.dishwasher_count }} ganger </p>
-      <p> Burns: {{ tenant.current_burn_count }} </p>
-      <p> Weekly chore: {{ tenant.weekly_chore.toLowerCase() }} </p>
+      <p>Tatt ut av oppvaskmaskinen {{ tenant.dishwasher_count }} ganger</p>
+      <p>Burns: {{ tenant.current_burn_count }}</p>
+      <p>Weekly chore: {{ tenant.weekly_chore.toLowerCase() }}</p>
       <p style="font-style:italic;">{{ tenant.favorite_quote }}</p>
       <button @click="openBurnForm(tenant)">Give Burn</button>
+      <button @click="showBurnHistory(tenant)">Show Burns</button>
     </div>
   </div>
-
   <div v-else>
     <p>Error</p>
   </div>
-
   <BurnFormComponent 
-    v-if="selectedTenant"
-    :receiver="selectedTenant"
-    @close="selectedTenant = null"
+    v-if="burnFormSelectedTenant"
+    :receiver="burnFormSelectedTenant"
+    @close="burnFormSelectedTenant = null"
   />
-
+  <TenantBurnHistoryComponent
+    v-if="burnHistorySelectedTenant"
+    :tenant="burnHistorySelectedTenant"
+    @close="burnHistorySelectedTenant = null"
+  />
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
 import BurnFormComponent from '@/components/BurnFormComponent.vue';
+import TenantBurnHistoryComponent from '@/components/TenantBurnHistoryComponent.vue';
 
 interface Tenant {
-  id: number,
-  name: string,
-  age: number,
-  image_url: string,
-  burn_count: number,
-  dishwasher_count: number,
-  favorite_quote: string
-  weekly_chore: string,
-  current_burn_count: number,
+  id: number;
+  name: string;
+  age: number;
+  image_url: string;
+  burn_count: number;
+  dishwasher_count: number;
+  favorite_quote: string;
+  weekly_chore: string;
+  current_burn_count: number;
 }
 
-export default defineComponent ({
-  name: "TenantComponent",
+export default defineComponent({
+  name: 'TenantComponent',
   components: {
     BurnFormComponent,
+    TenantBurnHistoryComponent
   },
   data() {
     return {
       tenants: [] as Tenant[],
-      selectedTenant: null as Tenant | null,
+      burnFormSelectedTenant: null as Tenant | null,
+      burnHistorySelectedTenant: null as Tenant | null
     };
   },
   async created() {
     try {
-      const response = await fetch("http://127.0.0.1:3001/tenants");
-
+      const response = await fetch('http://127.0.0.1:3001/tenants');
       if (!response.ok) {
-        throw new Error("Network response was not ok: " + response.statusText);
+        throw new Error('Network response was not ok: ' + response.statusText);
       }
-
-      const data: Tenant[] = await response.json(); // Type the fetched data as an array of Tenant
-
-      // Assign the response data to tenants
+      const data: Tenant[] = await response.json();
       this.tenants = data;
-
     } catch (error) {
-      console.error("Error fetching tenant data:", error);
+      console.error('Error fetching tenant data:', error);
     }
   },
   methods: {
     openBurnForm(tenant: Tenant) {
-      this.selectedTenant = tenant;
+      this.burnFormSelectedTenant = tenant;
     },
+    showBurnHistory(tenant: Tenant) {
+      this.burnHistorySelectedTenant = tenant;
+    }
   }
 });
 </script>
 
 <style scoped>
-  .all-tenants-div {
-    display: flex;
-    gap: 20px;
-    flex-wrap: wrap;
-    justify-content: space-evenly;
-  }
-  .tenant-div {
-    flex: 0 0 calc(33.33% - 20px);
-    background-color: lightcoral;
-    padding: 20px;
-    text-align: center;
-    box-sizing: border-box; /* Include padding in width calculation */
-  }
-  .tenant-div img {
-    width: 200px;
-    height: 200px;
-    object-fit: cover;
-  }
+.all-tenants-div {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
+}
+.tenant-div {
+  flex: 0 0 calc(33.33% - 20px);
+  background-color: lightcoral;
+  padding: 20px;
+  text-align: center;
+  box-sizing: border-box;
+}
+.tenant-div img {
+  width: 200px;
+  height: 200px;
+  object-fit: cover;
+}
 </style>


### PR DESCRIPTION
Yes this is a git copilot summary. This pull request introduces a new feature to display the burn history of tenants in the application. It includes changes to two Vue components: `TenantBurnHistoryComponent.vue` and `TenantComponent.vue`. The main changes are the addition of the burn history overlay and the integration of this new component into the existing tenant component.

New feature implementation:

* [`frontend/src/components/TenantBurnHistoryComponent.vue`](diffhunk://#diff-26e80d503f765600b0e373b820d12ce8234fae5fb5027018808c388bebacf1a4R1-R114): Added a new component to display the burn history of a tenant, including a template, script, and scoped styles. The component fetches burn data from an API and displays it in a list format.
* [`frontend/src/components/TenantComponent.vue`](diffhunk://#diff-a907e5194a380b95232657607c2d17d0e801d180244424b3ae81c842f7c93038R11-R77): Integrated the new `TenantBurnHistoryComponent` into the existing tenant component. Added a button to show the burn history and modified the data properties and methods to handle the display of the burn history overlay.

Minor style adjustment:

* [`frontend/src/components/TenantComponent.vue`](diffhunk://#diff-a907e5194a380b95232657607c2d17d0e801d180244424b3ae81c842f7c93038L90-R94): Fixed the indentation of the `box-sizing` property in the CSS to maintain consistency.