### PR TITLE
Removed who burn was given to

### DIFF
--- a/frontend/src/components/TenantBurnHistoryComponent.vue
+++ b/frontend/src/components/TenantBurnHistoryComponent.vue
@@ -14,7 +14,6 @@
             >
               <p>Reason: {{ burn.reason }}</p>
               <p>From: {{ burn.giver_name }}</p>
-              <p>To: {{ burn.receiver_name }}</p>
               <p>Created: {{ burn.created_at }}</p>
             </li>
           </ul>


### PR DESCRIPTION
This is redundant info as the tenant you show the burns for is the one who got the burns...