### PR TITLE
Fix: website crash if number of tenants less than number of chores

### DIFF
--- a/backend/src/utils.rs
+++ b/backend/src/utils.rs
@@ -13,7 +13,13 @@ pub fn get_weekly_chore(n_tenants: usize) -> Vec<String> {
         "Take out all trash".to_string(),
     ];
 
-    let n_missing = n_tenants - all_chores.len(); //Number of missing chores
+    let n_missing:usize; //Number of missing chores
+
+    if n_tenants > all_chores.len() {
+        n_missing = n_tenants - all_chores.len();
+    } else {
+        n_missing = 0;
+    }
 
     if n_missing > 0 {
         for _ in 0..(n_missing) {


### PR DESCRIPTION
Added check so that `n_missing:usize` does not get "casted" to negative number, which causes a crash