### PR TITLE
Added (bad) automatic resizing of tenant image

### DIFF
--- a/frontend/src/components/TenantFormComponent.vue
+++ b/frontend/src/components/TenantFormComponent.vue
@@ -106,7 +106,7 @@ export default defineComponent({
                             const newFile = new File([blob], file.name, { type: file.type });
                             resolve(newFile)
                         }, 
-                        "image/png", 
+                        file.type, 
                         1.0
                         );
                     }


### PR DESCRIPTION
Added code to automatically resize image into square. It does this automatically so that the square is approx in the middle. It is not a perfect solution, but an okay one while we develop manual resizing